### PR TITLE
Pretty printing of certificate exts

### DIFF
--- a/bin/webauthn_demo.ml
+++ b/bin/webauthn_demo.ml
@@ -1,5 +1,20 @@
 open Lwt.Infix
 
+let pp_cert =
+  let pp_extensions ppf (oid, data) =
+    let fido_u2f_transport_oid_name = "id-fido-u2f-ce-transports" in
+    if Asn.OID.equal oid Webauthn.fido_u2f_transport_oid then
+      match Webauthn.decode_transport data with
+      | Error `Msg _ ->
+        Fmt.pf ppf "%s invalid-data" fido_u2f_transport_oid_name
+      | Ok transports ->
+        Fmt.pf ppf "%s %a" fido_u2f_transport_oid_name
+          Fmt.(list ~sep:(any ",") Webauthn.pp_transport) transports
+    else
+      Fmt.pf ppf "unsupported %a: %a" Asn.OID.pp oid (Ohex.pp_hexdump ()) data
+  in
+  X509.Certificate.pp' pp_extensions
+
 let users : (string, string * (Mirage_crypto_ec.P256.Dsa.pub * string * X509.Certificate.t option) list) Hashtbl.t = Hashtbl.create 7
 
 let find_username username =
@@ -140,7 +155,7 @@ let add_routes t =
                 Option.fold ~none:("No certificate", "No certificate", Ok [])
                   ~some:(fun c ->
                            X509.Certificate.encode_pem c,
-                           Fmt.to_to_string X509.Certificate.pp c,
+                           Fmt.to_to_string pp_cert c,
                            Webauthn.transports_of_cert c)
                   certificate
               in

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -448,11 +448,11 @@ type transport = [
 ]
 
 let pp_transport ppf = function
-  | `Bluetooth_classic -> Fmt.string ppf "Bluetooth classic"
-  | `Bluetooth_low_energy -> Fmt.string ppf "Bluetooth low energy"
+  | `Bluetooth_classic -> Fmt.string ppf "BluetoothClassic"
+  | `Bluetooth_low_energy -> Fmt.string ppf "BluetoothLowEnergy"
   | `Usb -> Fmt.string ppf "USB"
   | `Nfc -> Fmt.string ppf "NFC"
-  | `Usb_internal -> Fmt.string ppf "USB internal"
+  | `Usb_internal -> Fmt.string ppf "USBInternal"
 
 let transports =
   let opts = [

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -168,6 +168,14 @@ type transport = [
 (** [pp_transport ppf tranport] pretty-prints the [transport] on [ppf]. *)
 val pp_transport : Format.formatter -> transport -> unit
 
+(** [fido_u2f_transport_oid] is the OID 1.3.6.1.4.1.45724.2.1.1 for
+    certificate authenticator transports extensions. *)
+val fido_u2f_transport_oid : Asn.oid
+
+(** [decode_transport data] decodes the [fido_u2f_transport_oid] certificate
+    extension data. *)
+val decode_transport : string -> (transport list, [> `Msg of string ]) result
+
 (** [transports_of_cert certficate] attempts to extract the FIDO U2F
     authenticator transports extension (OID 1.3.6.1.4.1.45724.2.1.1) from the
     [certificate].  *)


### PR DESCRIPTION
This exposes some X.509 extension details so we can pretty print certificates with Universal 2nd Factor (U2F) certificate transports extensions