### PR TITLE
Unified errors

### DIFF
--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -68,7 +68,7 @@ type challenge = string
 let generate_challenge ?(size = 32) () =
   if size < 16 then invalid_arg "size must be at least 16 bytes";
   let ch = Mirage_crypto_rng.generate size in
-  ch, Base64.encode_string ch
+  ch, Base64.encode_string ~pad:false ~alphabet:Base64.uri_safe_alphabet ch
 
 let challenge_to_string c = c
 let challenge_of_string s = Some s
@@ -306,7 +306,7 @@ type registration = {
 type register_response = {
   attestation_object : base64url_string [@key "attestationObject"];
   client_data_json : base64url_string [@key "clientDataJSON"];
-} [@@deriving of_yojson]
+} [@@deriving of_yojson { strict = false }]
 
 let register_response_of_string =
   of_json "register response" register_response_of_yojson
@@ -390,7 +390,7 @@ type authenticate_response = {
   client_data_json : base64url_string [@key "clientDataJSON"];
   signature : base64url_string ;
   userHandle : base64url_string option ;
-} [@@deriving of_yojson]
+} [@@deriving of_yojson { strict = false }]
 
 let authenticate_response_of_string =
   of_json "authenticate response" authenticate_response_of_yojson

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -29,7 +29,7 @@
 (** The type of a webauthn state, containing the [origin]. *)
 type t
 
-(** [create origin] is a webauthn state, or an error if the origin does not
+(** [create origin] is a webauthn state, or an error if [origin] does not
     meet the specification: schema must be https, the host must be a valid
     hostname. An optional port is supported: https://example.com:4444
 
@@ -120,7 +120,7 @@ type register_response
     clientDataJSON - both Base64 URI safe encoded). The result is a
     register_response or a decoding error. *)
 val register_response_of_string : string ->
-  (register_response, json_decoding_error) result
+  (register_response, [> json_decoding_error]) result
 
 (** [register t response] registers the response, and returns the used
     challenge and a registration. The challenge needs to be verified to be
@@ -129,7 +129,7 @@ val register_response_of_string : string ->
     chain between certificate and public key. The certificate should be
     validated by the caller. *)
 val register : t -> register_response ->
-  (challenge * registration, error) result
+  (challenge * registration, [> error]) result
 
 (** The type for an authentication. *)
 type authentication = {
@@ -148,7 +148,7 @@ type authenticate_response
     clientDataJSON, signature, userHandle). If decoding fails, an
     error is reported. *)
 val authenticate_response_of_string : string ->
-  (authenticate_response, json_decoding_error) result
+  (authenticate_response, [> json_decoding_error]) result
 
 (** [authenticate t public_key response] authenticates [response], by checking
     the signature with the [public_key]. If it is valid, the used [challenge]
@@ -157,7 +157,7 @@ val authenticate_response_of_string : string ->
     public key corresponding to the credential id returned by the client web
     browser. *)
 val authenticate : t -> Mirage_crypto_ec.P256.Dsa.pub -> authenticate_response ->
-  (challenge * authentication, error) result
+  (challenge * authentication, [> error]) result
 
 (** The type of FIDO U2F transports. *)
 type transport = [
@@ -183,4 +183,4 @@ val decode_transport : string -> (transport list, [> `Msg of string ]) result
     authenticator transports extension (OID 1.3.6.1.4.1.45724.2.1.1) from the
     [certificate].  *)
 val transports_of_cert : X509.Certificate.t ->
-  (transport list, [`Msg of string]) result
+  (transport list, [> `Msg of string]) result


### PR DESCRIPTION
Add some things needed for easier usage, like:

- Unify the polymorphic variant error types so they can be composed together
- Base-64 encode challenges in a way that will be understood by the standardized options JSON object parsing APIs
- Decode JSON received from the client in a non-strict way because clients will send stringified objects that have more fields than the ones we know about.

This PR is actually stacked on top of #8, I will of course rebase if and when that is merged.