### PR TITLE
Add `Simple` module

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
  (public_name webauthn)
  (preprocess
   (pps ppx_deriving_yojson))
- (libraries mirage-crypto-rng yojson mirage-crypto-ec x509 base64 cbor))
+ (libraries mirage-crypto-rng yojson mirage-crypto-ec x509 base64 cbor unix))

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
  (public_name webauthn)
  (preprocess
   (pps ppx_deriving_yojson))
- (libraries mirage-crypto-rng yojson mirage-crypto-ec x509 base64 cbor unix))
+ (libraries mirage-crypto-rng yojson mirage-crypto-ec x509 base64 cbor))

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -548,9 +548,7 @@ module Simple = struct
 
   let generate_registration_options
     ?attestation
-    ?(attestation_formats=[])
     ?(exclude_credentials=[])
-    ?(pub_key_cred_params=[])
     ?timeout
     ?(user_id=Mirage_crypto_rng.generate 16)
     ~user_name
@@ -559,18 +557,10 @@ module Simple = struct
     let user_id = b64enc user_id in
     {
       attestation;
-      attestation_formats = (
-        match attestation_formats with
-        | [] -> ["fido-u2f"]
-        | _ -> attestation_formats
-      );
+      attestation_formats = ["fido-u2f"];
       challenge = fst (generate_challenge ());
       exclude_credentials;
-      pub_key_cred_params = (
-        match pub_key_cred_params with
-        | [] -> [{ type_ = "public-key"; alg = -7 }]
-        | _ -> pub_key_cred_params
-      );
+      pub_key_cred_params = [{ type_ = "public-key"; alg = -7 }];
       rp = { id = rpid webauthn; name = webauthn.name };
       timeout;
       user = { id = user_id; name = user_name; display_name = display_name };

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -59,6 +59,7 @@ let pp_error ppf = function
   | `Signature_verification msg -> Fmt.pf ppf "signature verification failed %s" msg
 
 type t = {
+  name : string;
   origin : string;
   rpid : [`host] Domain_name.t;
 }
@@ -258,7 +259,7 @@ let json_assoc thing : Yojson.Safe.t -> ((string * Yojson.Safe.t) list, _) resul
   | `Assoc s -> Ok s
   | json -> Error (`Json_decoding (thing, "non-assoc", Yojson.Safe.to_string json))
 
-let create origin =
+let create ?(name="localhost") origin =
   match String.split_on_char '/' origin with
   | [ proto ; "" ; host_port ]
       when proto = "https:" || proto = "http:" && (String.equal host_port "localhost" || String.starts_with ~prefix:"localhost:" host_port) ->
@@ -280,7 +281,7 @@ let create origin =
                       with Failure _ -> Error ("invalid port " ^ port)))
         | _ -> Error ("invalid origin host and port " ^ host_port)
       with
-      | Ok host -> Ok { origin ; rpid = host }
+      | Ok host -> Ok { name ; origin ; rpid = host }
       | Error _ as e -> e
     end
   | _ ->  Error ("invalid origin " ^ origin)
@@ -480,3 +481,147 @@ let transports_of_cert c =
     (Option.to_result ~none:(`Msg "extension not present")
       (X509.Extension.(find (Unsupported fido_u2f_transport_oid) (X509.Certificate.extensions c))))
     (fun (_, data) -> decode_transport data)
+
+module Simple = struct
+  let b64enc str = Base64.encode_string ~pad:false ~alphabet:Base64.uri_safe_alphabet str
+
+  let b64dec str =
+    match Base64.decode ~pad:false ~alphabet:Base64.uri_safe_alphabet str with
+    | Ok s -> s
+    | Error (`Msg m) -> failwith m
+
+  let challenge_to_yojson c = `String (c |> challenge_to_string |> b64enc)
+
+  type credential = { id : string; type_ : string [@key "type"] } [@@deriving to_yojson]
+  type cred_param = { type_ : string [@key "type"]; alg : int } [@@deriving to_yojson]
+  type rp = { id : string; name : string } [@@deriving to_yojson]
+
+  type user = {
+    id : string;
+    name : string;
+    display_name : string [@key "displayName"];
+  } [@@deriving to_yojson]
+
+  type public_key_credential_creation_options = {
+    attestation : string option [@default None];
+    attestation_formats : string list [@key "attestationFormats"] [@default []];
+    challenge : challenge;
+    exclude_credentials : credential list [@key "excludeCredentials"] [@default []];
+    pub_key_cred_params : cred_param list [@key "pubKeyCredParams"] [@default []];
+    rp : rp;
+    timeout : (float option [@default None]);
+    user : user;
+  } [@@deriving to_yojson]
+
+  type public_key_credential_request_options = {
+    allow_credentials : credential list [@key "allowCredentials"] [@default []];
+    challenge : challenge;
+    rp_id : string [@key "rpId"];
+    timeout : float option [@default None];
+    user_verification : string option [@key "userVerification"] [@default None];
+  } [@@deriving to_yojson]
+
+  type pub_key = Mirage_crypto_ec.P256.Dsa.pub
+
+  let pub_key_to_yojson pk = `String (
+    pk
+    |> Mirage_crypto_ec.P256.Dsa.pub_to_octets
+    |> b64enc
+  )
+
+  let pub_key_of_yojson = function
+    | `String s ->
+      (match Mirage_crypto_ec.P256.Dsa.pub_of_octets (b64dec s) with
+      | Ok pk -> Ok pk
+      | Error _ -> Error "invalid public key")
+    | _ -> Error "invalid public key"
+
+  type passkey = {
+    credential_id : string;
+    user_id : string;
+    pub_key : pub_key;
+    aaguid : string;
+    counter : Int32.t;
+    created_at : float;
+    last_used : float;
+  } [@@deriving yojson { strict = false; exn = true }]
+
+  let generate_registration_options
+    ?attestation
+    ?(attestation_formats=[])
+    ?(exclude_credentials=[])
+    ?(pub_key_cred_params=[])
+    ?timeout
+    ?(user_id=Mirage_crypto_rng.generate 16)
+    ~user_name
+    ~display_name
+    webauthn =
+    let user_id = b64enc user_id in
+    {
+      attestation;
+      attestation_formats = (
+        match attestation_formats with
+        | [] -> ["fido-u2f"]
+        | _ -> attestation_formats
+      );
+      challenge = fst (generate_challenge ());
+      exclude_credentials;
+      pub_key_cred_params = (
+        match pub_key_cred_params with
+        | [] -> [{ type_ = "public-key"; alg = -7 }]
+        | _ -> pub_key_cred_params
+      );
+      rp = { id = rpid webauthn; name = webauthn.name };
+      timeout;
+      user = { id = user_id; name = user_name; display_name = display_name };
+    }
+
+  let or_invalid = function
+    | Ok v -> v
+    | Error e -> Fmt.kstr invalid_arg "error: %a" pp_error e
+
+  let verify_registration_response ~expected_challenge ~user_id response webauthn =
+    let challenge, registration = response
+      |> register_response_of_string
+      |> or_invalid
+      |> register webauthn
+      |> or_invalid
+    in
+    (if expected_challenge |> challenge_equal challenge |> not
+    then invalid_arg "verify_registration_response: challenge mismatch");
+
+    let created_at = Unix.time () in
+    {
+      user_id;
+      credential_id = b64enc registration.attested_credential_data.credential_id;
+      pub_key = registration.attested_credential_data.public_key;
+      aaguid = registration.attested_credential_data.aaguid;
+      counter = registration.sign_count;
+      created_at;
+      last_used = created_at;
+    }
+
+  let generate_authentication_options
+    ?(allow_credentials=[])
+    ?timeout
+    ?user_verification
+    webauthn = {
+    allow_credentials;
+    challenge = fst (generate_challenge ());
+    rp_id = rpid webauthn;
+    timeout;
+    user_verification;
+  }
+
+  let verify_authentication_response ~expected_challenge ~pub_key response webauthn =
+    let challenge, authentication = response
+      |> authenticate_response_of_string
+      |> or_invalid
+      |> authenticate webauthn pub_key
+      |> or_invalid
+    in
+    (if expected_challenge |> challenge_equal challenge |> not
+    then invalid_arg "verify_authentication_response: challenge mismatch");
+
+    authentication
+end

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -503,7 +503,12 @@ module Simple = struct
 
   let challenge_to_yojson c = `String (b64_urlenc (challenge_to_string c))
 
-  type credential = { id : string; type_ : string [@key "type"] } [@@deriving to_yojson]
+  type credential = {
+    id : string;
+    type_ : string [@key "type"];
+    transports : string list [@default []];
+  } [@@deriving to_yojson]
+
   type cred_param = { type_ : string [@key "type"]; alg : int } [@@deriving to_yojson]
   type rp = { id : string; name : string } [@@deriving to_yojson]
 

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -289,7 +289,12 @@ let create ?name origin =
                       with Failure _ -> Error ("invalid port " ^ port)))
         | _ -> Error ("invalid origin host and port " ^ host_port)
       with
-      | Ok host -> Ok { name = Option.value ~default:origin name ; origin ; rpid = host }
+      | Ok host ->
+        Ok {
+          name = Option.value name ~default:(Domain_name.to_string host) ;
+          origin ;
+          rpid = host ;
+        }
       | Error _ as e -> e
     end
   | _ ->  Error ("invalid origin " ^ origin)
@@ -537,7 +542,7 @@ module Simple = struct
       (match b64_urldec s with
       | Ok octets ->
         (match Mirage_crypto_ec.P256.Dsa.pub_of_octets octets with
-        | Ok _ as pub_key -> pub_key
+        | Ok _ as ok -> ok
         | Error e -> Fmt.error "%a" Mirage_crypto_ec.pp_error e)
       | Error (`Msg str) -> Error str)
     | _ -> Error "invalid JSON"

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -554,6 +554,7 @@ module Simple = struct
 
   type passkey = {
     credential_id : string;
+    display_name : string;
     user_id : string;
     pub_key : pub_key;
     aaguid : string;
@@ -582,13 +583,19 @@ module Simple = struct
       user = { id = user_id; name = user_name; display_name = display_name };
     }
 
-  let verify_registration_response ~expected_challenge ~user_id ~created_at response webauthn =
+  let verify_registration_response
+    ~expected_challenge
+    ~user_id
+    ~created_at
+    response
+    webauthn =
     let* register_response = register_response_of_string response in
     let* challenge, registration = register webauthn register_response in
     if challenge_equal expected_challenge challenge then
       Ok {
         user_id;
         credential_id = b64_urlenc registration.attested_credential_data.credential_id;
+        display_name = "Passkey";
         pub_key = registration.attested_credential_data.public_key;
         aaguid = registration.attested_credential_data.aaguid;
         sign_count = registration.sign_count;

--- a/src/webauthn.ml
+++ b/src/webauthn.ml
@@ -23,6 +23,8 @@ type error = [
   | `Rpid_hash_mismatch of string * string
   | `Missing_credential_data
   | `Signature_verification of string
+  | `Challenge_mismatch of string * string
+  | `Sign_count_mismatch of Int32.t * Int32.t
 ]
 
 let pp_error ppf = function
@@ -57,6 +59,10 @@ let pp_error ppf = function
       (Base64.encode_string should) (Base64.encode_string is)
   | `Missing_credential_data -> Fmt.string ppf "missing credential data"
   | `Signature_verification msg -> Fmt.pf ppf "signature verification failed %s" msg
+  | `Challenge_mismatch (expected, got) ->
+    Fmt.pf ppf "challenge mismatch: expected %s, received %s" expected got
+  | `Sign_count_mismatch (old, new_) ->
+    Fmt.pf ppf "sign count mismatch: old %ld, new %ld" old new_
 
 type t = {
   name : string;
@@ -261,7 +267,7 @@ let json_assoc thing : Yojson.Safe.t -> ((string * Yojson.Safe.t) list, _) resul
   | `Assoc s -> Ok s
   | json -> Error (`Json_decoding (thing, "non-assoc", Yojson.Safe.to_string json))
 
-let create ?(name="localhost") origin =
+let create ?name origin =
   match String.split_on_char '/' origin with
   | [ proto ; "" ; host_port ]
       when proto = "https:" || proto = "http:" && (String.equal host_port "localhost" || String.starts_with ~prefix:"localhost:" host_port) ->
@@ -283,7 +289,7 @@ let create ?(name="localhost") origin =
                       with Failure _ -> Error ("invalid port " ^ port)))
         | _ -> Error ("invalid origin host and port " ^ host_port)
       with
-      | Ok host -> Ok { name ; origin ; rpid = host }
+      | Ok host -> Ok { name = Option.value ~default:origin name ; origin ; rpid = host }
       | Error _ as e -> e
     end
   | _ ->  Error ("invalid origin " ^ origin)
@@ -485,12 +491,12 @@ let transports_of_cert c =
     (fun (_, data) -> decode_transport data)
 
 module Simple = struct
-  let b64_urldec str =
-    match Base64.decode ~pad:false ~alphabet:Base64.uri_safe_alphabet str with
-    | Ok s -> s
-    | Error (`Msg m) -> failwith m
+  let ( let* ) = Result.bind
 
-  let challenge_to_yojson c = `String (c |> challenge_to_string |> b64_urlenc)
+  let b64_urldec str =
+    Base64.decode ~pad:false ~alphabet:Base64.uri_safe_alphabet str
+
+  let challenge_to_yojson c = `String (b64_urlenc (challenge_to_string c))
 
   type credential = { id : string; type_ : string [@key "type"] } [@@deriving to_yojson]
   type cred_param = { type_ : string [@key "type"]; alg : int } [@@deriving to_yojson]
@@ -523,34 +529,34 @@ module Simple = struct
 
   type pub_key = Mirage_crypto_ec.P256.Dsa.pub
 
-  let pub_key_to_yojson pk = `String (
-    pk
-    |> Mirage_crypto_ec.P256.Dsa.pub_to_octets
-    |> b64_urlenc
-  )
+  let pub_key_to_yojson pk =
+    `String (b64_urlenc (Mirage_crypto_ec.P256.Dsa.pub_to_octets pk))
 
   let pub_key_of_yojson = function
     | `String s ->
-      (match Mirage_crypto_ec.P256.Dsa.pub_of_octets (b64_urldec s) with
-      | Ok pk -> Ok pk
-      | Error _ -> Error "invalid public key")
-    | _ -> Error "invalid public key"
+      (match b64_urldec s with
+      | Ok octets ->
+        (match Mirage_crypto_ec.P256.Dsa.pub_of_octets octets with
+        | Ok _ as pub_key -> pub_key
+        | Error e -> Fmt.error "%a" Mirage_crypto_ec.pp_error e)
+      | Error (`Msg str) -> Error str)
+    | _ -> Error "invalid JSON"
 
   type passkey = {
     credential_id : string;
     user_id : string;
     pub_key : pub_key;
     aaguid : string;
-    counter : Int32.t;
+    sign_count : Int32.t;
     created_at : float;
     last_used : float;
-  } [@@deriving yojson { strict = false; exn = true }]
+  } [@@deriving yojson { strict = false }]
 
   let generate_registration_options
     ?attestation
     ?(exclude_credentials=[])
     ?timeout
-    ?(user_id=Mirage_crypto_rng.generate 16)
+    ~user_id
     ~user_name
     ~display_name
     webauthn =
@@ -566,30 +572,20 @@ module Simple = struct
       user = { id = user_id; name = user_name; display_name = display_name };
     }
 
-  let or_invalid = function
-    | Ok v -> v
-    | Error e -> Fmt.kstr invalid_arg "error: %a" pp_error e
-
-  let verify_registration_response ~expected_challenge ~user_id response webauthn =
-    let challenge, registration = response
-      |> register_response_of_string
-      |> or_invalid
-      |> register webauthn
-      |> or_invalid
-    in
-    (if expected_challenge |> challenge_equal challenge |> not
-    then invalid_arg "verify_registration_response: challenge mismatch");
-
-    let created_at = Unix.time () in
-    {
-      user_id;
-      credential_id = b64_urlenc registration.attested_credential_data.credential_id;
-      pub_key = registration.attested_credential_data.public_key;
-      aaguid = registration.attested_credential_data.aaguid;
-      counter = registration.sign_count;
-      created_at;
-      last_used = created_at;
-    }
+  let verify_registration_response ~expected_challenge ~user_id ~created_at response webauthn =
+    let* register_response = register_response_of_string response in
+    let* challenge, registration = register webauthn register_response in
+    if challenge_equal expected_challenge challenge then
+      Ok {
+        user_id;
+        credential_id = b64_urlenc registration.attested_credential_data.credential_id;
+        pub_key = registration.attested_credential_data.public_key;
+        aaguid = registration.attested_credential_data.aaguid;
+        sign_count = registration.sign_count;
+        created_at;
+        last_used = created_at;
+      }
+    else Error (`Challenge_mismatch (expected_challenge, challenge))
 
   let generate_authentication_options
     ?(allow_credentials=[])
@@ -603,15 +599,16 @@ module Simple = struct
     user_verification;
   }
 
-  let verify_authentication_response ~expected_challenge ~pub_key response webauthn =
-    let challenge, authentication = response
-      |> authenticate_response_of_string
-      |> or_invalid
-      |> authenticate webauthn pub_key
-      |> or_invalid
+  let verify_authentication_response ~expected_challenge ~passkey response webauthn =
+    let* authenticate_response = authenticate_response_of_string response in
+    let* challenge, authentication =
+      authenticate webauthn passkey.pub_key authenticate_response
     in
-    (if expected_challenge |> challenge_equal challenge |> not
-    then invalid_arg "verify_authentication_response: challenge mismatch");
-
-    authentication
+    if challenge_equal expected_challenge challenge then
+      if Int32.(
+        unsigned_compare authentication.sign_count passkey.sign_count > 0
+        || equal authentication.sign_count zero && equal passkey.sign_count zero
+      ) then Ok authentication
+      else Error (`Sign_count_mismatch (passkey.sign_count, authentication.sign_count))
+    else Error (`Challenge_mismatch (expected_challenge, challenge))
 end

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -291,7 +291,7 @@ module Simple : sig
       be encoded into a JSON string and then decoded in the browser. Parameters
       are as described here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
-        https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
+      https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
 
       @param user_id defaults to a randomly-generated 16-byte string. Override it
         to specify IDs from your user database.
@@ -299,7 +299,7 @@ module Simple : sig
       Example usage in server:
 
       {[
-      let options = Simple.generate_registration_options ...  in
+      let options = Simple.generate_registration_options ... in
       ...
 
       options
@@ -309,8 +309,9 @@ module Simple : sig
       ]}
 
       Browsers can now use
-      {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static} PublicKeyCredential.parseCreationOptionsFromJSON}
-      to decode the JSON into the options object:
+      {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static}
+      PublicKeyCredential.parseCreationOptionsFromJSON} to decode the JSON into
+      the options object:
 
       {@javascript[
       const optionsStr = await fetch(...);
@@ -352,7 +353,7 @@ module Simple : sig
       a JSON string and then decoded in the browser. Parameters are as described
       here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#instance_properties}
-        https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#instance_properties}
+      https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#instance_properties}
 
       Example usage in server:
 
@@ -367,8 +368,9 @@ module Simple : sig
       ]}
 
       Browsers can now use
-      {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseRequestOptionsFromJSON_static} PublicKeyCredential.parseRequestOptionsFromJSON}
-      to decode the JSON into the options object:
+      {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseRequestOptionsFromJSON_static}
+      PublicKeyCredential.parseRequestOptionsFromJSON} to decode the JSON into
+      the options object:
 
       {@javascript[
       const optionsStr = await fetch(...);

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -1,6 +1,6 @@
 (** WebAuthn - authenticating users to services using public key cryptography
 
-    For a simple passkey-focused API, see the {!Simple} module.
+    For a simplified passkey-focused API, see the {!Simple} module.
 
     WebAuthn is a web standard published by the W3C. Its goal is to
     standardize an interfacefor authenticating users to web-based
@@ -267,7 +267,7 @@ module Simple : sig
 
       Suggested storage schema (adapt to your needs):
 
-      {[
+      {@sql[
       create table passkey (
         id text primary key,
         user_id text not null foreign key references user (id),
@@ -279,27 +279,22 @@ module Simple : sig
 
   val generate_registration_options :
     ?attestation:string ->
-    ?attestation_formats:string list ->
     ?exclude_credentials:credential list ->
-    ?pub_key_cred_params:cred_param list ->
     ?timeout:float ->
     ?user_id:string ->
     user_name:string ->
     display_name:string ->
     t ->
     public_key_credential_creation_options
-  (** [generate_registration_options ?attestation ?attestation_formats
-      ?exclude_credentials ?pub_key_cred_params ?timeout ?user_id ~user_name
-      ~display_name webauthn] is an options object that can be encoded into a
-      JSON string and then decoded in the browser. Parameters are as described
-      here:
+  (** [generate_registration_options ?attestation ?exclude_credentials ?timeout
+      ?user_id ~user_name ~display_name webauthn] is an options object that can
+      be encoded into a JSON string and then decoded in the browser. Parameters
+      are as described here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
         https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
 
       @param user_id defaults to a randomly-generated 16-byte string. Override it
         to specify IDs from your user database.
-      @param attestation_formats defaults to [fido-u2f]
-      @param pub_key_cred_params defaults to [{"type": "public-key", "alg": -7}]
 
       Example usage in server:
 

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -291,7 +291,7 @@ module Simple : sig
       be encoded into a JSON string and then decoded in the browser. Parameters
       are as described here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
-      https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
+      PublicKeyCredentialCreationOptions instance properties}
 
       @param user_id defaults to a randomly-generated 16-byte string. Override it
         to specify IDs from your user database.
@@ -353,7 +353,7 @@ module Simple : sig
       a JSON string and then decoded in the browser. Parameters are as described
       here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#instance_properties}
-      https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#instance_properties}
+      PublicKeyCredentialRequestOptions instance properties}
 
       Example usage in server:
 

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -395,9 +395,9 @@ module Simple : sig
       // Upload credential.id and response to server
       ]}
 
-      The [pub_key] can be obtained by looking up the stored passkey
-      corresponding to [credential.id] obtained from the above JavaScript snippet,
-      and getting its public key.
+      The [pub_key] can be obtained by looking up the stored {!passkey}
+      corresponding to [credential.id] obtained from the client, and getting its
+      public key.
 
       @raise Invalid_argument if authentication verification fails. *)
 end

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -264,6 +264,10 @@ module Simple : sig
     credential_id : string;
     (** Use this as the lookup key when storing passkeys. *)
 
+    display_name : string;
+    (** Human-readable name for displaying the passkey in UIs. Defaults to
+        [Passkey]. *)
+
     user_id : string;
     (** Foreign key referencing the users table. See also
         {!generate_registration_options}. *)

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -276,10 +276,11 @@ module Simple : sig
     last_used : float;
     (** Update this timestamp after each authentication ceremony. *)
   } [@@deriving yojson]
-  (** Store this in persistent storage. Values can be converted into JSON strings
-      using [passkey |> Simple.passkey_to_yojson |> Yojson.Safe.to_string]. And
-      converted from JSON strings using
-      [str |> Yojson.Safe.from_string |> Simple.passkey_of_yojson_exn].
+  (** Store this in persistent storage. Values can be serialized into JSON
+      strings using
+      [passkey |> Simple.passkey_to_yojson |> Yojson.Safe.to_string], and
+      deserialized using
+      [str |> Yojson.Safe.from_string |> Simple.passkey_of_yojson].
 
       Suggested storage schema (adapt to your needs):
 
@@ -309,6 +310,8 @@ module Simple : sig
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
       PublicKeyCredentialCreationOptions instance properties}
 
+      @param exclude_credentials the default is to {e not exclude} any
+        credentials.
       @param user_id must be a user identifier from your user database to allow a
         single user to have multiple passkeys.
 
@@ -370,6 +373,8 @@ module Simple : sig
       here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#instance_properties}
       PublicKeyCredentialRequestOptions instance properties}
+
+      @param allow_credentials the default is to allow {e any} credentials.
 
       Example usage in server:
 

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -32,7 +32,7 @@
 type t
 
 (** [create ?name origin] is a webauthn state for a relying party [name] (default
-    ["localhost"]) and hostname [origin], or an error if the [origin] does not
+    [origin]) and hostname [origin], or an error if the [origin] does not
     meet the specification: schema must be https, the host must be a valid
     hostname. An optional port is supported: https://example.com:4444
 
@@ -73,6 +73,19 @@ type error = [
   | `Rpid_hash_mismatch of string * string
   | `Missing_credential_data
   | `Signature_verification of string
+
+  | `Challenge_mismatch of string * string
+  (** Expected and received challenges are not matching either during
+      registration or authentication. *)
+
+  | `Sign_count_mismatch of Int32.t * Int32.t
+  (** Order: passkey counter, authenticator counter
+
+      Signature count received from the client's authenticator is not strictly
+      larger than the stored sign count in our passkey. This could indicate a
+      compromised authenticator. See
+      {{: https://w3c.github.io/webauthn/#sctn-sign-counter}Signature Counter
+      Considerations}. *)
 ]
 
 (** [pp_error ppf e] pretty-prints the error [e] on [ppf]. *)
@@ -198,9 +211,6 @@ val transports_of_cert : X509.Certificate.t ->
     - {!Simple.generate_authentication_options}
     - {!Simple.verify_authentication_response}
 
-    The 'verify' functions raise [Invalid_argument] in case any of the
-    verification steps fails.
-
     @since 0.3.0 *)
 module Simple : sig
   (** {2 JSON objects}
@@ -246,20 +256,22 @@ module Simple : sig
     (** Use this as the lookup key when storing passkeys. *)
 
     user_id : string;
-    (** Foreign key referencing the users table. *)
+    (** Foreign key referencing the users table. See also
+        {!generate_registration_options}. *)
 
     pub_key : pub_key;
     aaguid : string;
 
-    counter : Int32.t;
-    (** Increment this after each successful authentication ceremony. *)
+    sign_count : Int32.t;
+    (** Set this to the value of [authentication.sign_count] after each
+        successful authentication ceremony. *)
 
     created_at : float;
-    (** Current time on server at creation using [Unix.time ()]. *)
+    (** Current time on server at creation using [Unix.time ()] or equivalent. *)
 
     last_used : float;
     (** Update this timestamp after each authentication ceremony. *)
-  } [@@deriving yojson { exn = true }]
+  } [@@deriving yojson]
   (** Store this in persistent storage. Values can be converted into JSON strings
       using [passkey |> Simple.passkey_to_yojson |> Yojson.Safe.to_string]. And
       converted from JSON strings using
@@ -281,20 +293,20 @@ module Simple : sig
     ?attestation:string ->
     ?exclude_credentials:credential list ->
     ?timeout:float ->
-    ?user_id:string ->
+    user_id:string ->
     user_name:string ->
     display_name:string ->
     t ->
     public_key_credential_creation_options
   (** [generate_registration_options ?attestation ?exclude_credentials ?timeout
-      ?user_id ~user_name ~display_name webauthn] is an options object that can
+      ~user_id ~user_name ~display_name webauthn] is an options object that can
       be encoded into a JSON string and then decoded in the browser. Parameters
       are as described here:
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
       PublicKeyCredentialCreationOptions instance properties}
 
-      @param user_id defaults to a randomly-generated 16-byte string. Override it
-        to specify IDs from your user database.
+      @param user_id must be a user identifier from your own user database to
+        allow a single user to have multiple passkeys.
 
       Example usage in server:
 
@@ -323,12 +335,15 @@ module Simple : sig
   val verify_registration_response :
     expected_challenge:challenge ->
     user_id:string ->
+    created_at:float ->
     string ->
     t ->
-    passkey
-  (** [verify_registration_response ~expected_challenge ~user_id response
-      webauthn] is a passkey constructed after verifying the registration
-      response.
+    (passkey, error) result
+  (** [verify_registration_response ~expected_challenge ~user_id ~created_at
+      response webauthn] is a passkey constructed after verifying the
+      registration response.
+
+      @param created_at is set as the value of [passkey.created_at].
 
       The [response] can be obtained with something like this:
 
@@ -336,9 +351,7 @@ module Simple : sig
       const credential = await navigator.credentials.create({ publicKey: options });
       const response = JSON.stringify(credential.toJSON().response);
       // Upload response to server
-      ]}
-
-      @raise Invalid_argument if registration verification fails. *)
+      ]} *)
 
   (** {2:auth Authentication ceremony} *)
 
@@ -381,25 +394,24 @@ module Simple : sig
 
   val verify_authentication_response :
     expected_challenge:challenge ->
-    pub_key:pub_key ->
+    passkey:passkey ->
     string ->
     t ->
-    authentication
-  (** [verify_authentication_response ~expected_challenge ~pub_key response
+    (authentication, error) result
+  (** [verify_authentication_response ~expected_challenge ~passkey response
       webauthn] is an [authentication] object constructed after verifying the
-      authentication response.
+      authentication response and signature counters.
 
-      The [response] can be obtained with something like this:
+      The [response] can be obtained from the client with something like this:
 
       {@javascript[
       const credential = await navigator.credentials.get({ publicKey: options });
-      const response = JSON.stringify(credential.toJSON().response);
-      // Upload credential.id and response to server
+      const responseStr = JSON.stringify(credential.toJSON().response);
+
+      // Upload credential.id and response to server:
+      fetch('/authenticate/' + credential.id, { method: 'POST', body: responseStr });
       ]}
 
-      The [pub_key] can be obtained by looking up the stored {!passkey}
-      corresponding to [credential.id] obtained from the client, and getting its
-      public key.
-
-      @raise Invalid_argument if authentication verification fails. *)
+      The [passkey] can be obtained on the server with a lookup of the
+      corresponding [credential.id] obtained from the client. *)
 end

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -222,7 +222,12 @@ module Simple : sig
       These declarations are needed for JSON encoding. You can skip ahead to
       {!reg} and {!auth} which will create these for you. *)
 
-  type credential = { id : string; type_ : string }
+  type credential = {
+    id : string;
+    type_ : string;
+    transports : string list;
+  }
+
   type cred_param = { type_ : string; alg : int }
   type rp = { id : string; name : string }
 
@@ -319,7 +324,7 @@ module Simple : sig
 
       {[
       let options = Simple.generate_registration_options ... in
-      ...
+      ...temporarily store options.challenge and options.user.id...
 
       options
       |> Simple.public_key_credential_creation_options_to_yojson
@@ -380,7 +385,7 @@ module Simple : sig
 
       {[
       let options = Simple.generate_authentication_options webauthn in
-      ...
+      ...temporarily store options.challenge...
 
       options
       |> Simple.public_key_credential_request_options_to_yojson

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -76,7 +76,9 @@ type error = [
 
   | `Challenge_mismatch of string * string
   (** Expected and received challenges are not matching either during
-      registration or authentication. *)
+      registration or authentication.
+
+      @since 0.3.0 *)
 
   | `Sign_count_mismatch of Int32.t * Int32.t
   (** Order: passkey counter, authenticator counter
@@ -85,7 +87,9 @@ type error = [
       larger than the stored sign count in our passkey. This could indicate a
       compromised authenticator. See
       {{: https://w3c.github.io/webauthn/#sctn-sign-counter}Signature Counter
-      Considerations}. *)
+      Considerations}.
+
+      @since 0.3.0 *)
 ]
 
 (** [pp_error ppf e] pretty-prints the error [e] on [ppf]. *)
@@ -305,8 +309,8 @@ module Simple : sig
       {{: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#instance_properties}
       PublicKeyCredentialCreationOptions instance properties}
 
-      @param user_id must be a user identifier from your own user database to
-        allow a single user to have multiple passkeys.
+      @param user_id must be a user identifier from your user database to allow a
+        single user to have multiple passkeys.
 
       Example usage in server:
 

--- a/src/webauthn.mli
+++ b/src/webauthn.mli
@@ -348,8 +348,7 @@ module Simple : sig
       registration response.
 
       @param created_at is set as the value of [passkey.created_at].
-
-      The [response] can be obtained with something like this:
+      @param response can be obtained with something like this:
 
       {@javascript[
       const credential = await navigator.credentials.create({ publicKey: options });
@@ -406,7 +405,7 @@ module Simple : sig
       webauthn] is an [authentication] object constructed after verifying the
       authentication response and signature counters.
 
-      The [response] can be obtained from the client with something like this:
+      @param response can be obtained from the client with something like this:
 
       {@javascript[
       const credential = await navigator.credentials.get({ publicKey: options });
@@ -416,6 +415,6 @@ module Simple : sig
       fetch('/authenticate/' + credential.id, { method: 'POST', body: responseStr });
       ]}
 
-      The [passkey] can be obtained on the server with a lookup of the
-      corresponding [credential.id] obtained from the client. *)
+      @param passkey can be obtained on the server with a lookup of the
+        corresponding [credential.id] obtained from the client. *)
 end


### PR DESCRIPTION
Add a module that introduces simplified registration & authentication ceremony operations.

This is broadly modelled after the functions in the [@simplewebauthn/server](https://simplewebauthn.dev/docs/packages/server) npm package.